### PR TITLE
fix main entry in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gatsby-plugin",
     "seo"
   ],
-  "main": "/index.js",
+  "main": "index.js",
   "scripts": {
     "prepack": "yarn build",
     "build": "babel src -d . --presets gatsby-package --extensions .ts,.tsx"


### PR DESCRIPTION
- Fix warning
```
Invalid 'main' field in '/Users/mj/workspace/pr-post/websites/node_modules/gatsby-plugin-dedupe-head/package.json' of '/index.js'. Please either fix
that or report it to the module author
```